### PR TITLE
Updating API / Fixing ROS1 errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Note: These instructions assume your workspace is named ``catkin_ws``. If your w
    
 3. Clone the RadarIQ ROS repository into the src directory.
 
-   ``git clone https://github.com/radariq/ros ./src/radariq_ros``
+   ``git clone https://github.com/radariq/ros1 ./src/radariq_ros``
 
 4. Run catkin_make to make the workspace.
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ In this tutorial you will learn how to:
 3. Visualize the data using RViz.
 4. Configure settings and incorporate the module into an existing ROS project.
 
+# Install Python SDK
+Install the Python SDK by running
+
+``pip install radariq``
+
 # Configure Linux
 By default USB devices are presented to the Linux Kernel as /dev/ttyACMxx (where xx is a number).
 The exact device name changes depending on the order in which the USB devices are connected or detected by the kernel.

--- a/launch/radariq_objects.launch
+++ b/launch/radariq_objects.launch
@@ -32,7 +32,7 @@
     <!-- Desired density of points (0 = low, 1 = med, 2 = high) -->
     <param name="pointdensity"        type="int"    value="1"/>
 
-    <!-- Desired level of point certainty to apply (0 - 9) -->
-    <param name="certainty"           type="int"    value="5"/>
+    <!-- Desired level of point sensitivity to apply (0 - 9) -->
+    <param name="sensitivity"         type="int"    value="5"/>
   </node>
 </launch>

--- a/launch/radariq_pointcloud.launch
+++ b/launch/radariq_pointcloud.launch
@@ -29,7 +29,7 @@
     <!-- Desired density of points (0 = low, 1 = med, 2 = high) -->
     <param name="pointdensity"        type="int"    value="1"/>
 
-    <!-- Desired level of point certainty to apply (0 - 9) -->
-    <param name="certainty"           type="int"    value="5"/>
+    <!-- Desired level of point sensitivity to apply (0 - 9) -->
+    <param name="sensitivity"         type="int"    value="5"/>
   </node>
 </launch>

--- a/scripts/example_application.py
+++ b/scripts/example_application.py
@@ -31,7 +31,7 @@ import rospy
 from sensor_msgs.msg import PointCloud2
 
 def callback(data):
-    rospy.loginfo(rospy.get_caller_id(), data)
+    rospy.loginfo("Data received at %s", rospy.get_caller_id())
 
 def listener():
     rospy.init_node('RadarIQExampleApplication', anonymous=True)

--- a/scripts/object_publisher_node.py
+++ b/scripts/object_publisher_node.py
@@ -89,7 +89,7 @@ def run():
     anglefilter_min = rospy.get_param('~anglefilter_min')
     anglefilter_max = rospy.get_param('~anglefilter_max')
     pointdensity = rospy.get_param('~pointdensity')
-    certainty = rospy.get_param('~certainty')
+    sensitivity = rospy.get_param('~sensitivity')
     marker_topic = rospy.get_param('~marker_topic')
     object_data_topic = rospy.get_param('~object_data_topic')
     frame_id = rospy.get_param('~frame_id')
@@ -107,7 +107,7 @@ def run():
         riq.set_distance_filter(distancefilter_min, distancefilter_max)
         riq.set_angle_filter(anglefilter_min, anglefilter_max)
         riq.set_point_density(pointdensity)
-        riq.set_certainty(certainty)
+        riq.set_sensitivity(sensitivity)
         riq.start()
         rospy.loginfo("Starting the RadarIQ module")
 

--- a/scripts/pointcloud_publisher_node.py
+++ b/scripts/pointcloud_publisher_node.py
@@ -50,7 +50,7 @@ def run():
     anglefilter_min = rospy.get_param('~anglefilter_min')
     anglefilter_max = rospy.get_param('~anglefilter_max')
     pointdensity = rospy.get_param('~pointdensity')
-    certainty = rospy.get_param('~certainty')
+    sensitivity = rospy.get_param('~sensitivity')
 
     topic = rospy.get_param('~topic')
     frame_id = rospy.get_param('~frame_id')
@@ -60,7 +60,8 @@ def run():
     fields = [PointField('x', 0, PointField.FLOAT32, 1),
               PointField('y', 4, PointField.FLOAT32, 1),
               PointField('z', 8, PointField.FLOAT32, 1),
-              PointField('intensity', 16, PointField.FLOAT32, 1),
+              PointField('intensity', 12, PointField.UINT8, 1),
+              PointField('velocity', 13, PointField.FLOAT32, 1),
               ]
 
     header = Header()
@@ -74,7 +75,7 @@ def run():
         riq.set_distance_filter(distancefilter_min, distancefilter_max)
         riq.set_angle_filter(anglefilter_min, anglefilter_max)
         riq.set_point_density(pointdensity)
-        riq.set_certainty(certainty)
+        riq.set_sensitivity(sensitivity)
         riq.start()
         rospy.loginfo("Starting the RadarIQ module")
 

--- a/scripts/radariq
+++ b/scripts/radariq
@@ -1,1 +1,0 @@
-/home/radariq/riq_ws/src/radariq_ros/scripts/python-sdk/radariq/


### PR DESCRIPTION
There is a bit of mismatch between the python API installed from pypi and the API used here. Specifically, certainty is replaced with sensitivity (mentioned in #2). 

Furthermore, the device sends 5 fields (I found what they mean from [this line](https://github.com/radariq/c-sdk/blob/d669613c0eb41fe524c06fdbc58b76d4209ad306/src/RadarIQ.h#L169)) , but only 4 PointFields are provided (mentioned in #3 #4). I am adding the 5th field with possibly subobtimal padding, but if the user needs velocity, they will be able to retrieve it from the point cloud as well.

Also fixing the installation instructions (mentioned in #1)